### PR TITLE
Feature/cut first then extract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-#Osmaxx Data Wrangling
+# Osmaxx Data Wrangling
+
 This contains all the scripts regarding the Osmaxx database.

--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -7,6 +7,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update &&\
     DEBIAN_FRONTEND=noninteractive apt-get install -y\
     postgresql-client\
     osmosis\
+    osmctools\
     wget
 
 WORKDIR $HOME

--- a/bootstrap/main-bootstrap.sh
+++ b/bootstrap/main-bootstrap.sh
@@ -58,7 +58,7 @@ init_osmosis() {
 fill_initial_osm_data(){
 echo "*** fill initial OSM data ***"
     wget -nc -q --progress=bar http://download.geofabrik.de/europe/switzerland-latest.osm.pbf -O  $WORKDIR_OSM/switzerland-latest.osm.pbf
-    osmconvert $WORKDIR_OSM/switzerland-latest.osm.pbf -b=${EAST},${SOUTH},${WEST},${NORTH} -o=$WORKDIR_OSM/excerpt.osm.pbf
+    osmconvert $WORKDIR_OSM/switzerland-latest.osm.pbf -b=${WEST},${SOUTH},${EAST},${NORTH} -o=$WORKDIR_OSM/excerpt.osm.pbf
     osm2pgsql --slim --create --extra-attributes --database $DB_NAME \
         --prefix osm --style $DIR/src/terminal.style --tag-transform-script $DIR/src/style.lua\
         --number-processes 8 --username postgres --hstore-all --input-reader pbf $WORKDIR_OSM/excerpt.osm.pbf
@@ -83,9 +83,9 @@ filterdata(){
 
 STARTTIME=$(date +%s)
 
-EAST=${1}
+WEST=${1}
 SOUTH=${2}
-WEST=${3}
+EAST=${3}
 NORTH=${4}
 
 # setup_db && init_osmosis  && fill_initial_osm_data  && cleandata && filterdata

--- a/bootstrap/main-bootstrap.sh
+++ b/bootstrap/main-bootstrap.sh
@@ -58,9 +58,10 @@ init_osmosis() {
 fill_initial_osm_data(){
 echo "*** fill initial OSM data ***"
     wget -nc -q --progress=bar http://download.geofabrik.de/europe/switzerland-latest.osm.pbf -O  $WORKDIR_OSM/switzerland-latest.osm.pbf
+    osmconvert $WORKDIR_OSM/switzerland-latest.osm.pbf -b=${EAST},${SOUTH},${WEST},${NORTH} -o=$WORKDIR_OSM/excerpt.osm.pbf
     osm2pgsql --slim --create --extra-attributes --database $DB_NAME \
         --prefix osm --style $DIR/src/terminal.style --tag-transform-script $DIR/src/style.lua\
-        --number-processes 8 --username postgres --hstore-all --input-reader pbf $WORKDIR_OSM/switzerland-latest.osm.pbf
+        --number-processes 8 --username postgres --hstore-all --input-reader pbf $WORKDIR_OSM/excerpt.osm.pbf
 }
 
 # http://petereisentraut.blogspot.ch/2010/03/running-sql-scripts-with-psql.html
@@ -81,6 +82,12 @@ filterdata(){
 }
 
 STARTTIME=$(date +%s)
+
+EAST=${1}
+SOUTH=${2}
+WEST=${3}
+NORTH=${4}
+
 # setup_db && init_osmosis  && fill_initial_osm_data  && cleandata && filterdata
 setup_db && init_osmosis  && fill_initial_osm_data && createfunctions && cleandata && filterdata
 # filterdata


### PR DESCRIPTION
For performance reasons, cut the `.osm.pbf` to the wanted bouding box even before importing into the database.

Reviewed by:
- [x] @njordan-hsr
- [ ] @Dhruv222
- [ ] @sfkeller