### PR TITLE
Feature/10 support esri file geodatabase

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ bootstrap:
   environment:
     - PGHOST=database
   volumes:
-    - tmp/osmosis/:/tmp/osmosis/
+    - ./tmp/osmosis/:/tmp/osmosis/
 extract:
   build: extract/
   links:
@@ -13,6 +13,6 @@ extract:
   environment:
     - PGHOST=database
   volumes:
-    - results:/home/excerpt/data/
+    - ./results:/home/excerpt/data/
 database:
   image: geometalab/postgis-with-translit

--- a/extract/Dockerfile
+++ b/extract/Dockerfile
@@ -1,9 +1,13 @@
-FROM ubuntu:15.04
+# this gdal image comes with support for FileGDB
+FROM geodata/gdal:2.0.0
 
-RUN apt-get update && apt-get install -y\
+# unfortunately, the image used starts with the user 'nobody'
+USER root
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python\
     postgresql-client\
-    gdal-bin\
     zip
 
 ENV HOME /home/excerpt

--- a/extract/Dockerfile
+++ b/extract/Dockerfile
@@ -1,7 +1,8 @@
 # this gdal image comes with support for FileGDB
 FROM geodata/gdal:2.0.0
 
-# unfortunately, the image used starts with the user 'nobody'
+# unfortunately, the image geodata/gdal used starts with the user 'nobody'
+# so a switch is necessary first
 USER root
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \


### PR DESCRIPTION
Closes #10 

* update docker-compose to use the, starting with docker-compose 1.4, newer syntax
* using a different base image so FileGDB support is available

Manual test suggests it is working as expected (ignoring the warnings), a non-empty gdb file-structure is being created. `ogrinfo -al data/osmaxx_excerpt_2015-09-27_093120.gdb` lists many results.

Reviewed by:
* [ ] @das-g 
* [x] @wasabideveloper 
* [ ] @Dhruv222 

Manual test output log (shortened):

```shell

# setting up the db
docker-compose run bootstrap /bin/bash -c 'sleep 10 && sh main-bootstrap.sh 8.775449276 47.1892350573 8.8901920319 47.2413633153'
# ...
# running the extract for filegdb
docker-compose run extract /bin/bash -c \
  'python excerpt.py 8.775449276 47.1892350573 8.8901920319 47.2413633153 -f fgdb'
Calculating Statistics...
Statistics Done!!
exporting to osmaxx_excerpt_2015-09-27_093120.gdb
Warning 1: The output driver does not seem to natively support Integer64 type for field osm_id. Converting it to Real instead. -mapFieldType can be used to control field type conversion.
# ...
osmaxx_excerpt_2015-09-27_093120.gdb have been Generated.. Zipping files
  adding: data/osmaxx_excerpt_2015-09-27_093120.gdb/ (stored 0%)
  adding: data/osmaxx_excerpt_2015-09-27_093120.gdb/a00000019.gdbtablx (deflated 64%)
# ...
Zip done! Exiting....
osmaxx_excerpt_2015-09-27_093120 have been completed in fgdb format.
```