### PR TITLE
some more learning tests for RQ

### DIFF
--- a/tests/learning/__init__.py
+++ b/tests/learning/__init__.py
@@ -1,0 +1,5 @@
+"""
+Tests that don't test our own code, but show us (and let us explore) how foreign code can be used and how it (re)acts.
+
+These tests might still use some of our own code as utility to facilitate testing of foreign code.
+"""

--- a/tests/learning/__init__.py
+++ b/tests/learning/__init__.py
@@ -1,5 +1,6 @@
 """
 Tests that don't test our own code, but show us (and let us explore) how foreign code can be used and how it (re)acts.
 
-These tests might still use some of our own code as utility to facilitate testing of foreign code.
+These tests might still use some of our own code as utility to facilitate testing of foreign code, but the focus is on
+functionality of the foreign code.
 """

--- a/tests/learning/rq_test.py
+++ b/tests/learning/rq_test.py
@@ -14,12 +14,12 @@ def store_helloworld_in_job():
 
 
 class RQMetaDataTests(django.test.TestCase):
-    def test_meta_not_available_without_fetch(self, *args, **kwargs):
+    def test_stored_metadata_is_not_available_on_original_job_proxy_object(self, *args, **kwargs):
         job = rq_enqueue_with_settings(store_helloworld_in_job)
         perform_all_jobs_sync()
         self.assertDictEqual(job.meta, {})
 
-    def test_meta_retrieval_with_fetch_succeeds(self, *args, **kwargs):
+    def test_stored_metadata_can_be_retrieved_from_freshly_fetched_job(self, *args, **kwargs):
         job = rq_enqueue_with_settings(store_helloworld_in_job)
         perform_all_jobs_sync()
         job_fetched = Job.fetch(job.id, connection=get_connection())

--- a/tests/learning/rq_test.py
+++ b/tests/learning/rq_test.py
@@ -7,7 +7,7 @@ from manager.rq_helper import rq_enqueue_with_settings
 from tests.redis_test_helpers import perform_all_jobs_sync
 
 
-def hello():
+def store_helloworld_in_job():
     job = get_current_job(connection=get_connection())
     job.meta['world'] = 'hello'
     job.save()
@@ -15,12 +15,12 @@ def hello():
 
 class RQConnectionTests(django.test.TestCase):
     def test_meta_not_available_without_fetch(self, *args, **kwargs):
-        job = rq_enqueue_with_settings(hello)
+        job = rq_enqueue_with_settings(store_helloworld_in_job)
         perform_all_jobs_sync()
         self.assertDictEqual(job.meta, {})
 
     def test_meta_retrieval_with_fetch_succeeds(self, *args, **kwargs):
-        job = rq_enqueue_with_settings(hello)
+        job = rq_enqueue_with_settings(store_helloworld_in_job)
         perform_all_jobs_sync()
         job_fetched = Job.fetch(job.id, connection=get_connection())
         self.assertDictEqual(job_fetched.meta, {'world': 'hello'})

--- a/tests/learning/rq_test.py
+++ b/tests/learning/rq_test.py
@@ -17,6 +17,10 @@ def return_result():
     return 'the result'
 
 
+def return_nontrivial_pickleable_object():
+    return {'the result': ['can', b'e', ('an arbitrary', 'pickleable'), object]}
+
+
 class RQMetaDataTests(django.test.TestCase):
     def test_stored_metadata_is_not_available_on_original_job_proxy_object(self, *args, **kwargs):
         job = rq_enqueue_with_settings(store_helloworld_in_job)
@@ -42,3 +46,8 @@ class RQResultTest(django.test.TestCase):
         job = rq_enqueue_with_settings(return_result)
         perform_all_jobs_sync()
         self.assertEqual(job.result, 'the result')
+
+    def test_result_can_be_an_arbitrary_pickleable_object(self):
+        job = rq_enqueue_with_settings(return_nontrivial_pickleable_object)
+        perform_all_jobs_sync()
+        self.assertEqual(job.result, return_nontrivial_pickleable_object())

--- a/tests/learning/rq_test.py
+++ b/tests/learning/rq_test.py
@@ -29,6 +29,13 @@ class RQMetaDataTests(django.test.TestCase):
         job_fetched = Job.fetch(job.id, connection=get_connection())
         self.assertDictEqual(job_fetched.meta, {'world': 'hello'})
 
+    def test_stored_metadata_value_can_be_an_arbitrary_pickleable_object(self):
+        nontrivial_pickleable_object = {'the value': ['can', b'e', ('an arbitrary', 'pickleable'), object]}
+        job = rq_enqueue_with_settings(store_in_job, 'world', nontrivial_pickleable_object)
+        perform_all_jobs_sync()
+        job_fetched = Job.fetch(job.id, connection=get_connection())
+        self.assertDictEqual(job_fetched.meta, {'world': nontrivial_pickleable_object})
+
 
 class RQResultTest(django.test.TestCase):
     def test_result_is_not_available_before_job_has_run(self):

--- a/tests/learning/rq_test.py
+++ b/tests/learning/rq_test.py
@@ -7,9 +7,9 @@ from manager.rq_helper import rq_enqueue_with_settings
 from tests.redis_test_helpers import perform_all_jobs_sync
 
 
-def store_helloworld_in_job():
+def store_in_job(key, value):
     job = get_current_job(connection=get_connection())
-    job.meta['world'] = 'hello'
+    job.meta[key] = value
     job.save()
 
 
@@ -19,12 +19,12 @@ def return_result(result):
 
 class RQMetaDataTests(django.test.TestCase):
     def test_stored_metadata_is_not_available_on_original_job_proxy_object(self, *args, **kwargs):
-        job = rq_enqueue_with_settings(store_helloworld_in_job)
+        job = rq_enqueue_with_settings(store_in_job, 'world', 'hello')
         perform_all_jobs_sync()
         self.assertDictEqual(job.meta, {})
 
     def test_stored_metadata_can_be_retrieved_from_freshly_fetched_job(self, *args, **kwargs):
-        job = rq_enqueue_with_settings(store_helloworld_in_job)
+        job = rq_enqueue_with_settings(store_in_job, 'world', 'hello')
         perform_all_jobs_sync()
         job_fetched = Job.fetch(job.id, connection=get_connection())
         self.assertDictEqual(job_fetched.meta, {'world': 'hello'})

--- a/tests/learning/rq_test.py
+++ b/tests/learning/rq_test.py
@@ -13,12 +13,8 @@ def store_helloworld_in_job():
     job.save()
 
 
-def return_result():
-    return 'the result'
-
-
-def return_nontrivial_pickleable_object():
-    return {'the result': ['can', b'e', ('an arbitrary', 'pickleable'), object]}
+def return_result(result):
+    return result
 
 
 class RQMetaDataTests(django.test.TestCase):
@@ -43,11 +39,12 @@ class RQResultTest(django.test.TestCase):
             perform_all_jobs_sync()
 
     def test_result_is_available_after_job_has_run(self):
-        job = rq_enqueue_with_settings(return_result)
+        job = rq_enqueue_with_settings(return_result, 'the result')
         perform_all_jobs_sync()
         self.assertEqual(job.result, 'the result')
 
     def test_result_can_be_an_arbitrary_pickleable_object(self):
-        job = rq_enqueue_with_settings(return_nontrivial_pickleable_object)
+        nontrivial_pickleable_object = {'the result': ['can', b'e', ('an arbitrary', 'pickleable'), object]}
+        job = rq_enqueue_with_settings(return_result, nontrivial_pickleable_object)
         perform_all_jobs_sync()
-        self.assertEqual(job.result, return_nontrivial_pickleable_object())
+        self.assertEqual(job.result, nontrivial_pickleable_object)

--- a/tests/learning/rq_test.py
+++ b/tests/learning/rq_test.py
@@ -13,7 +13,7 @@ def store_helloworld_in_job():
     job.save()
 
 
-class RQConnectionTests(django.test.TestCase):
+class RQMetaDataTests(django.test.TestCase):
     def test_meta_not_available_without_fetch(self, *args, **kwargs):
         job = rq_enqueue_with_settings(store_helloworld_in_job)
         perform_all_jobs_sync()

--- a/tests/learning/rq_test.py
+++ b/tests/learning/rq_test.py
@@ -36,6 +36,14 @@ class RQMetaDataTests(django.test.TestCase):
         job_fetched = Job.fetch(job.id, connection=get_connection())
         self.assertDictEqual(job_fetched.meta, {'world': nontrivial_pickleable_object})
 
+    def test_stored_metadata_key_can_be_an_arbitrary_hashable_object(self):
+        nontrivial_hashable_object = ('the key', ('can', b'e', ('an arbitrary', 'hashable'), object))
+        job = rq_enqueue_with_settings(store_in_job, nontrivial_hashable_object, 'hello')
+        perform_all_jobs_sync()
+        job_fetched = Job.fetch(job.id, connection=get_connection())
+        self.assertEqual(job_fetched.meta[nontrivial_hashable_object], 'hello')
+
+
 
 class RQResultTest(django.test.TestCase):
     def test_result_is_not_available_before_job_has_run(self):

--- a/tests/learning/rq_test.py
+++ b/tests/learning/rq_test.py
@@ -18,12 +18,12 @@ def return_result(result):
 
 
 class RQMetaDataTests(django.test.TestCase):
-    def test_stored_metadata_is_not_available_on_original_job_proxy_object(self, *args, **kwargs):
+    def test_stored_metadata_is_not_available_on_original_job_proxy_object(self):
         job = rq_enqueue_with_settings(store_in_job, 'world', 'hello')
         perform_all_jobs_sync()
         self.assertDictEqual(job.meta, {})
 
-    def test_stored_metadata_can_be_retrieved_from_freshly_fetched_job(self, *args, **kwargs):
+    def test_stored_metadata_can_be_retrieved_from_freshly_fetched_job(self):
         job = rq_enqueue_with_settings(store_in_job, 'world', 'hello')
         perform_all_jobs_sync()
         job_fetched = Job.fetch(job.id, connection=get_connection())


### PR DESCRIPTION
@wasabideveloper:
* In case you'll have to implement anything using [RQ](http://python-rq.org/) (according to our plans from this morning, you won't have to), these illustrative tests should get you started on its basic usage.
* Please note that these tests require a running Redis instance. [Our documentation](https://github.com/geometalab/osmaxx-postgis-conversion/blob/c57e95b43378ed233cd0e67d595719984d88be30/docs/index.md#testing) explains how to start it locally.
* About pickleability of objects, see [the Python `pickle` documentation](https://docs.python.org/3/library/pickle.html#what-can-be-pickled-and-unpickled)
* About hashablility ob objects, see [the Python glossary](https://docs.python.org/3/glossary.html)

### Reviewed by:
- [x] @njordan-hsr 
- [x] @wasabideveloper 