### PR TITLE
Add workaround for strange docker permission issue

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -107,6 +107,10 @@ RUN sed --in-place 's/\$\(CXX\) $\(LIBS\) -shared -o \$@ \$</\$\(CXX\) -shared -
 
 ENV HOME /home/py
 
+# Workaround for AUFS-related(?) permission issue:
+# See https://github.com/docker/docker/issues/783#issuecomment-56013588
+RUN mkdir /etc/ssl/private-copy; mv /etc/ssl/private/* /etc/ssl/private-copy/; rm -r /etc/ssl/private; mv /etc/ssl/private-copy /etc/ssl/private; chmod -R 0700 /etc/ssl/private; chown -R postgres /etc/ssl/private
+
 # activate translit
 RUN mkdir -p $HOME/conversion_service/worker $HOME/entrypoint
 COPY ./docker_entrypoint/worker $HOME/entrypoint


### PR DESCRIPTION
To get rid of `Starting PostgreSQL 9.3 database server: mainThe PostgreSQL server failed to start. Please check the log output: [...] [23-1] FATAL: could not access private key file "/etc/ssl/private/ssl-cert-snakeoil.key": Permission denied ... failed!` on das-g's system.

See [j0hnsmith's comment docker/docker#783](https://github.com/docker/docker/issues/783\#issuecomment-56013588).

###### Reviewed by:
- [x] @wasabideveloper
- [x] @hixi