### PR TITLE
Require status URL to be present for notification of the job's callback

### DIFF
--- a/conversion_service/worker/converter_job.py
+++ b/conversion_service/worker/converter_job.py
@@ -48,9 +48,12 @@ class Notifier(object):
 
         :param callback_url:
         :return: nothing
+        :raises ValueError if status_url missing but callback_url is present
         """
         if self.callback_url:
-            data = {'status': self.status_url} if self.status_url is not None else {}
+            if self.status_url is None:
+                raise ValueError
+            data = {'status': self.status_url}
             try:
                 requests.get(self.callback_url, params=data)
             except:  # pragma: nocover

--- a/tests/worker/worker_test.py
+++ b/tests/worker/worker_test.py
@@ -122,7 +122,7 @@ class NotifierTest(TestCase):
         self.assertEqual(requests_send_mock.call_count, 0)
 
     @patch.object(requests.sessions.Session, 'send')
-    def test_notify_without_status_url_fails(self, requests_send_mock):
+    def test_notify_without_status_url_raises_value_error(self, requests_send_mock):
         notifier = Notifier(
             callback_url='http://osmaxx-ui.example.com/update_job_status/',
             status_url=None

--- a/tests/worker/worker_test.py
+++ b/tests/worker/worker_test.py
@@ -121,5 +121,16 @@ class NotifierTest(TestCase):
         notifier.notify()
         self.assertEqual(requests_send_mock.call_count, 0)
 
+    @patch.object(requests.sessions.Session, 'send')
+    def test_notify_without_status_url_fails(self, requests_send_mock):
+        notifier = Notifier(
+            callback_url='http://osmaxx-ui.example.com/update_job_status/',
+            status_url=None
+        )
+        self.assertRaises(
+            ValueError,
+            notifier.notify
+        )
+
     def _get_request(self, request, **kwargs):
         return request


### PR DESCRIPTION
Reviewed by:
- [x] @hixi
- [ ] @wasabideveloper