### PR TITLE
worker should be allowed to work for 24 hours

### DIFF
--- a/conversion_service/manager/rq_helper.py
+++ b/conversion_service/manager/rq_helper.py
@@ -10,7 +10,7 @@ def rq_enqueue_with_settings(function, *args, **kwargs):
         function,
         result_ttl=converter_settings.OSMAXX_CONVERSION_SERVICE['RESULT_TTL'],
         ttl=timedelta(days=1).seconds,  # max time in the queue, before it is considered lost
-        timeout=timedelta(hours=10).seconds,  # max time the worker may spend, before the job is cancelled
+        timeout=timedelta(days=1).seconds,  # max time the worker may spend, before the job is cancelled
         *args,
         **kwargs
     )

--- a/conversion_service/manager/rq_helper.py
+++ b/conversion_service/manager/rq_helper.py
@@ -1,12 +1,16 @@
+from datetime import timedelta
+
 import django_rq
 
 from converters import converter_settings
 
 
 def rq_enqueue_with_settings(function, *args, **kwargs):
-        return django_rq.enqueue(
-            function,
-            result_ttl=converter_settings.OSMAXX_CONVERSION_SERVICE['RESULT_TTL'],
-            *args,
-            **kwargs
-        )
+    return django_rq.enqueue(
+        function,
+        result_ttl=converter_settings.OSMAXX_CONVERSION_SERVICE['RESULT_TTL'],
+        ttl=timedelta(days=1).seconds,  # max time in the queue, before it is considered lost
+        timeout=timedelta(hours=10).seconds,  # max time the worker may spend, before the job is cancelled
+        *args,
+        **kwargs
+    )


### PR DESCRIPTION
...without timing out.

A queued job shold not timeout for a day.

Reviewed by:

- [x] @das-g 
- [x] @wasabideveloper 

