### PR TITLE
set the dsn for the worker to sync as django-rq documented

### DIFF
--- a/conversion_service/config/settings/worker.py
+++ b/conversion_service/config/settings/worker.py
@@ -68,6 +68,6 @@ if SENTRY_DSN:
     }
 
     RAVEN_CONFIG = {
-        'dsn': SENTRY_DSN,
+        'dsn': "sync+" + SENTRY_DSN,
         'release': env.str('SENTRY_RELEASE', default=''),
     }


### PR DESCRIPTION
Fix for sentry not receiving errors from worker.